### PR TITLE
blockrewards and some params

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1542,13 +1542,11 @@ int64_t GetProofOfWorkReward(int nHeight, int64_t nFees)
 		nSubsidy = 132000000 * COIN;  // 22% Premine premine of 600M MAX SUPPLY 
 	else if (pindexBest->nHeight <= FAIR_LAUNCH_BLOCK) // Block 210, Instamine prevention
         nSubsidy = 1 * COIN/2;
-	else if (pindexBest->nHeight <= 1000000) // Block 1m ~ 3m (33% will go to hybrid fortunastakes)
-		nSubsidy = 3 * COIN;
-	else if (pindexBest->nHeight <= 2000000) // Block 2m ~ 4m
-		nSubsidy = 4 * COIN;
-	else if (pindexBest->nHeight <= 3000000) // Block 3m ~ 3m
-		nSubsidy = 3 * COIN;
-    else if (pindexBest->nHeight > LAST_POW_BLOCK) // Block 3m
+	else if (pindexBest->nHeight <= 250000) //(33% will go to hybrid fortunastakes)
+		nSubsidy = 600 * COIN;
+	else if (pindexBest->nHeight <= 500000)
+		nSubsidy = 300 * COIN;
+    else if (pindexBest->nHeight > LAST_POW_BLOCK) // Block 500k
 		nSubsidy = 0; // PoW Ends
 
     if (fDebug && GetBoolArg("-printcreation"))

--- a/src/main.h
+++ b/src/main.h
@@ -59,7 +59,7 @@ class CNode;
 
 // General Cleo Block Values
 
-static const int LAST_POW_BLOCK = 3000000; // Block 3m Approx. 3 years of Proof of Work before Proof of Stake consensus kicks in
+static const int LAST_POW_BLOCK = 500000; // Block 500k. ~2 year of Hybrid until 100% POS
 static const int FAIR_LAUNCH_BLOCK = 210; // Last Block until full block reward starts
 static const unsigned int MAX_BLOCK_SIZE = 1000000; // 1MB block hard limit, double the size of Bitcoin
 static const unsigned int MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/2; // 512kb block soft limit, ditto
@@ -74,7 +74,7 @@ static const int64_t MIN_TX_FEE = 1000;
 static const int64_t MIN_TX_FEE_ANON = 10000;
 static const int64_t MIN_RELAY_TX_FEE = MIN_TX_FEE;
 static const int64_t MAX_MONEY = 600000000 * COIN; // 600.000.000 CLEO Max
-static const int64_t COIN_YEAR_REWARD = 0.06 * COIN; // 6% per year
+static const int64_t COIN_YEAR_REWARD = 0.05 * COIN; // 6% per year
 
 static const int64_t MAINNET_POSFIX = 640000; //Mainnet Proof of Stake update not enabled until block 640k
 static const int MN_ENFORCEMENT_ACTIVE_HEIGHT = 1450000; // Enforce fortunastake payments after this height - BLOCK 1.45 Million


### PR DESCRIPTION
"The maximum supply of CLEO is 600 million coins. Of this, 22% will be premined which will be used for the development of the project. This leaves 468 million coins to be available for either mining or staking.
The hybrid phase will last approximately 2 years. With a blocktime of 2 minutes, every 0.95 years 250 thousand blocks will be mined. The initial blockreward is 600 CLEO and halves every 250 thousand blocks or, every 0.95 years. Of the rewards, 70% goes to POW and 30% to POS. After these 2 years, 225 million coins (48%) of the available supply will be mined/staked. The remaining 243 million coins will be staked in the 100% POS phase. With a staking return of 5% a year, after approximately 15 years, all coins will be created. "

Blockreward parameters, LAST_POW_REWARD, staking reward.